### PR TITLE
expose mount_program and mountopt

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,3 +26,9 @@ containers_common_engine_cgroup_manager: "systemd"
 
 # Default Storage Driver
 containers_common_storage_driver: "overlay"
+
+# Default Storage Mount Program
+containers_common_storage_mount_program: ""
+
+# Default Storage Mount Options
+containers_common_storage_mountopt: ""

--- a/templates/etc/containers/storage.conf.j2
+++ b/templates/etc/containers/storage.conf.j2
@@ -73,10 +73,13 @@ additionalimagestores = [
 
 # Path to an helper program to use for mounting the file system instead of mounting it
 # directly.
+{% if containers_common_storage_mount_program is defined and containers_common_storage_mount_program|length %}
+mount_program = "{{ containers_common_storage_mount_program }}"
+{% else %}
 #mount_program = "/usr/bin/fuse-overlayfs"
-
+{% endif %}
 # mountopt specifies comma separated list of extra mount options
-mountopt = ""
+mountopt = "{{containers_common_storage_mountopt}}"
 
 # Set to skip a PRIVATE bind mount on the storage home directory.
 # skip_mount_home = "false"


### PR DESCRIPTION
adding variables for mount_program and mountopt. These are needed when using molecule + docker driver to test roles that start podman containers. (inside of docker)